### PR TITLE
v0.1.1 - adding config for default branch

### DIFF
--- a/repokit/cli.py
+++ b/repokit/cli.py
@@ -81,6 +81,12 @@ def parse_arguments() -> argparse.Namespace:
         "--private-branch",
         help="Name of the private branch (default: private)"
     )
+
+    # Default branch override
+    parser.add_argument(
+        "--default-branch",
+        help="Name of the default branch (default: main)"
+    )
     
     # Branch strategy options
     parser.add_argument(
@@ -303,6 +309,10 @@ def args_to_config(args: argparse.Namespace) -> Dict[str, Any]:
     
     if branch_directories:
         cli_config["branch_config"] = {"branch_directories": branch_directories}
+
+    # default branch from CLI
+    if args.default_branch:
+        cli_config["default_branch"] = args.default_branch
     
     # Remove None values from config
     return {k: v for k, v in cli_config.items() if v is not None}

--- a/repokit/config.py
+++ b/repokit/config.py
@@ -39,6 +39,7 @@ class ConfigManager:
             "name": "my-project",
             "description": "A new project repository",
             "language": "generic",
+            "default_branch": "main",
             "branches": ["main", "dev", "staging", "test", "live"],
             "worktrees": ["main", "dev"],
             "directories": [
@@ -146,7 +147,11 @@ class ConfigManager:
             
             if "private_branch" not in self.cli_config:
                 self.config["private_branch"] = strategy.get("private_branch", "private")
-            
+
+            # Ensure default_branch aligns
+            if "default_branch" not in self.cli_config:
+                self.config["default_branch"] = self.config.get("default_branch", "main")
+				
             if self.verbose >= 1:
                 self.logger.info(f"Applied branch strategy '{strategy_name}'")
 

--- a/repokit/remote_integration.py
+++ b/repokit/remote_integration.py
@@ -71,15 +71,15 @@ class RemoteIntegration:
             "Accept": "application/vnd.github.v3+json"
         }
         
+        default_branch = self.repo_manager.config.get("default_branch", "main")
         data = {
             "name": repo_name,
             "description": description,
             "private": private,
-            "auto_init": False,  # Don't initialize with README
-            # Explicitly set default branch to main
-            "default_branch": "main"
+            "auto_init": False,      # Don't initialize with README
+            "default_branch": default_branch
         }
-        
+
         # API endpoint - either user repos or organization repos
         if organization:
             url = f"{api_url}/orgs/{organization}/repos"

--- a/repokit/repo_manager.py
+++ b/repokit/repo_manager.py
@@ -208,8 +208,8 @@ class RepoManager:
         # Create branches
         branches = self.config.get('branches', ['main', 'dev', 'staging', 'test', 'live'])
         
-        # Ensure main branch exists (might be called master in some cases)
-        default_branch = 'main'
+        # Ensure the configured default branch exists
+        default_branch = self.config.get('default_branch', 'main')
         current_branch = self.run_git(["branch", "--show-current"], cwd=self.repo_root)
         
         if current_branch != default_branch:
@@ -235,10 +235,10 @@ class RepoManager:
         self.logger.info("Setting up worktrees")
         
         # Get branches to create worktrees for
-        worktree_branches = self.config.get('worktrees', ['main', 'dev'])
-        
-        # Always add GitHub directory as worktree with main branch if main is in worktree list
-        main_branch = 'main'
+        worktree_branches = self.config.get('worktrees', [self.config.get('default_branch', 'main'), 'dev'])
+
+        # Always add GitHub directory as worktree with the default branch if it’s in the list
+        main_branch = self.config.get('default_branch', 'main')
         if main_branch in worktree_branches:
             # Get directory name for main branch from branch_config
             github_dir = self.config.get('branch_config', {}).get('branch_directories', {}).get(main_branch, 'github')


### PR DESCRIPTION
Tested `..\scripts\bootstrap_simple.py --name git-repokit2 --publish-to github --credentials-file credentials.json`

Haven't tested new standalone config.json, but since bootstrap generates these files it should all work.